### PR TITLE
Fix make DESTDIR=<blah> install by passing DESTDIR to sub-Makefiles.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -92,7 +92,8 @@ FLAGS_TO_PASS = \
 	TAR="$(TAR)" \
 	TARFLAGS="$(TARFLAGS)" \
 	TARFILEEXT="$(TARFILEEXT)" \
-	WINDRES="$(WINDRES)"
+	WINDRES="$(WINDRES)" \
+	DESTDIR="$(DESTDIR)"
 
 # end config section
 

--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -104,7 +104,8 @@ FLAGS_TO_PASS = \
 	TAR="$(TAR)" \
 	TARFLAGS="$(TARFLAGS)" \
 	TARFILEEXT="$(TARFILEEXT)" \
-	WINDRES="$(WINDRES)"
+	WINDRES="$(WINDRES)" \
+	DESTDIR="$(DESTDIR)"
 
 # end config section
 

--- a/libce/Makefile.in
+++ b/libce/Makefile.in
@@ -198,17 +198,29 @@ lib%.a: %.o
 	$(AR) rc $@ $*.o
 	$(RANLIB) $@
 
+need-DESTDIR-compatibility = prefix libdir includedir
+.PHONY: $(need-DESTDIR-compatibility) fail-DESTDIR-compatibility
+
+$(need-DESTDIR-compatibility):
+	@test -z "$(DESTDIR)" || case "$($@)" in ?:*) \
+	  $(MAKE) --no-print-directory reject="$@" fail-DESTDIR-compatibility ;; \
+	esac
+
+fail-DESTDIR-compatibility:
+	$(error DESTDIR is not supported when $(reject) contains Win32 path `$($(reject))'; \
+	try `make install $(reject)=$(shell echo '$($(reject))' | sed s,:,:$(DESTDIR),) ...' instead)
+
 .PHONY: install install-libraries install-headers
 # install headers and libraries in a target specified directory.
 install: install-libraries install-headers
 
-install-libraries: all
+install-libraries: all $(need-DESTDIR-compatibility)
 	$(mkinstalldirs) $(DESTDIR)$(inst_libdir)
 	for i in $(LIBS); do \
 		$(INSTALL_DATA) $$i $(DESTDIR)$(inst_libdir)/$$i ; \
 	done
 
-install-headers:
+install-headers: $(need-DESTDIR-compatibility)
 	$(mkinstalldirs) $(DESTDIR)$(inst_includedir)
 	for i in $(HEADERS); do \
 		$(INSTALL_DATA) $(srcdir)/../include/$$i $(DESTDIR)$(inst_includedir)/$$i ; \

--- a/libce/Makefile.in
+++ b/libce/Makefile.in
@@ -203,19 +203,19 @@ lib%.a: %.o
 install: install-libraries install-headers
 
 install-libraries: all
-	$(mkinstalldirs) $(inst_libdir)
+	$(mkinstalldirs) $(DESTDIR)$(inst_libdir)
 	for i in $(LIBS); do \
-		$(INSTALL_DATA) $$i $(inst_libdir)/$$i ; \
+		$(INSTALL_DATA) $$i $(DESTDIR)$(inst_libdir)/$$i ; \
 	done
 
 install-headers:
-	$(mkinstalldirs) $(inst_includedir)
+	$(mkinstalldirs) $(DESTDIR)$(inst_includedir)
 	for i in $(HEADERS); do \
-		$(INSTALL_DATA) $(srcdir)/../include/$$i $(inst_includedir)/$$i ; \
+		$(INSTALL_DATA) $(srcdir)/../include/$$i $(DESTDIR)$(inst_includedir)/$$i ; \
 	done
-	$(mkinstalldirs) $(inst_includedir)/GL
+	$(mkinstalldirs) $(DESTDIR)$(inst_includedir)/GL
 	for i in $(GL_HEADERS); do \
-		$(INSTALL_DATA) $(srcdir)/../include/GL/$$i $(inst_includedir)/GL/$$i ; \
+		$(INSTALL_DATA) $(srcdir)/../include/GL/$$i $(DESTDIR)$(inst_includedir)/GL/$$i ; \
 	done
 
 # uninstall headers and libraries from a target specified directory


### PR DESCRIPTION
Previously this is partially ignored which upsets some distro packaging tools (e.g. makepkg).